### PR TITLE
Only show the overlay during the alignment phase

### DIFF
--- a/RedefineGuide/Models/SurgeryModel.swift
+++ b/RedefineGuide/Models/SurgeryModel.swift
@@ -22,6 +22,9 @@ class SurgeryModel: NSObject, ObservableObject {
     /// Only useful if errorExists is true.  Contains some details of the error message like: "Device is in low power mode.  Turn off low power mode to re-enable recording"
     @Published private(set) var errorMessage: String = ""
 
+    /// The bounding box of the overlay.  Only useful during the aligning phase
+    @Published var overlayBounds: CGRect? = nil
+    
     var delegate: SurgeryModelDelegate? = nil
     private var logger = RedefineLogger("SurgeryModel")
 

--- a/RedefineGuide/Views/ARViewContainer.swift
+++ b/RedefineGuide/Views/ARViewContainer.swift
@@ -3,14 +3,53 @@ import SceneKit
 import ARKit
 
 /// Contains the ARSCNView that the ARSession and SceneKit is drawn on
+/// If there is an overlayBounds set by the model, everything except the overlayBounds is blurred out.  This is for the alignment phase
 struct ARViewContainer: UIViewRepresentable {
     @ObservedObject var model: SurgeryModel
-
+    
     func makeUIView(context: Context) -> ARSCNView {
         return model.getARView()
     }
+    
+    func updateUIView(_ uiView: ARSCNView, context: Context) {
+        updateMask(in: uiView, for: model.overlayBounds)
+    }
+    
+    private func getBlurEffectView(_ view: UIView) -> UIVisualEffectView? {
+        return view.subviews.first(where: { $0 is UIVisualEffectView }) as? UIVisualEffectView
+    }
 
-    func updateUIView(_ uiView: ARSCNView, context: Context) {}
+    private func updateMask(in view: UIView, for bounds: CGRect?) {
+        if let bounds = bounds {
+            if let blurEffectView = getBlurEffectView(view), let maskLayer = blurEffectView.layer.mask as? CAShapeLayer {
+                maskLayer.path = createCutoutPath(bounds: bounds, blurEffectView: blurEffectView)
+                return
+            }
+            // Everything to create the blur effect
+            let blurEffect = UIBlurEffect(style: .systemThinMaterial)
+            let blurEffectView = UIVisualEffectView(effect: blurEffect)
+            blurEffectView.frame = view.bounds
+            blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            blurEffectView.isUserInteractionEnabled = false // Allows user interaction to pass through to the ARSCNView
+            view.addSubview(blurEffectView)
+            let maskLayer = CAShapeLayer()
+            maskLayer.fillRule = .evenOdd
+            maskLayer.path = createCutoutPath(bounds: bounds, blurEffectView: blurEffectView)
+            blurEffectView.layer.mask = maskLayer
+        } else {
+            // Get rid of the blur effect, otherwise things will go wonky
+            if let blurEffectView = getBlurEffectView(view) {
+                blurEffectView.removeFromSuperview()
+            }
+        }
+    }
+    
+    /// Creates a path that is used to cut out the blur to show only the overlay during the alignment phase
+    private func createCutoutPath(bounds: CGRect, blurEffectView: UIVisualEffectView) -> CGMutablePath {
+        let path = CGMutablePath()
+        // Add a subpath which is the area we want to see
+        path.addRect(blurEffectView.bounds)
+        path.addRoundedRect(in: bounds, cornerWidth: 5.0, cornerHeight: 5.0)
+        return path
+    }
 }
-
-


### PR DESCRIPTION
This calculates a bounding box around the overlay and blurs out everything else during the alignment phase